### PR TITLE
Fix path concatenation for *nix

### DIFF
--- a/test/TestUtil.py
+++ b/test/TestUtil.py
@@ -45,7 +45,7 @@ def read_user_info(conf = None):
         
 def get_authorization_code(signin_url):
 
-    user_config_path = os.path.join(os.path.split(__file__)[0], 'config\\test-config-sample.yaml')
+    user_config_path = os.path.join(os.path.join(os.path.split(__file__)[0], 'config'), 'test-config-sample.yaml')
     read_user_info(user_config_path)
     
     env_key = production_key


### PR DESCRIPTION
This switches to using `os.path.join` instead of `\\` in a string literal which only works on Windows.