### PR TITLE
Fix invalid scope issue in get_application_token method (Generated by Ana - AI SDE)

### DIFF
--- a/oauthclient/oauth2api.py
+++ b/oauthclient/oauth2api.py
@@ -62,6 +62,8 @@ class oauth2api(object):
             makes call for application token and stores result in credential object
             returns credential object
         """
+        # Fix: reducing the scope list to the valid one
+        scopes = ["https://api.ebay.com/oauth/api_scope"]
       
         logging.info("Trying to get a new application access token ... ")        
         credential = credentialutil.get_credentials(env_type)       


### PR DESCRIPTION
### Description
This PR addresses an issue with the broad app_scope in the `get_application_token` method. The `app_scopes` list has been limited to the valid scope to prevent the `invalid_scope` error.

### Changes
- **Modified**: `get_application_token` in `oauthclient/oauth2api.py` to use the correct scope: `https://api.ebay.com/oauth/api_scope`

This patch was generated by [Ana - AI SDE](https://openana.ai/), an AI-powered software development assistant.

Fixes [Issue 9](https://github.com/eBay/ebay-oauth-python-client/issues/9)